### PR TITLE
Security Change

### DIFF
--- a/main.py
+++ b/main.py
@@ -89,7 +89,7 @@ async def on_message(message):
             return await message.reply('`changed to embed split(Giorgio#0609)`')
 
 if __name__ == "__main__":
-    TOKEN = config_read()['TOKEN']
+    TOKEN = os.getenv("os")
 
     for file in os.listdir("./cogs"):
         if file.endswith(".py"):


### PR DESCRIPTION
Replit free accounts do not have the ability to make private repositories, this means that by editing the config.json file they create their own replit fork of the project viewable on their profile page where people can view their token, the edit allows for the usage of "Replit Secrets" not viewable by other people.