### PR TITLE
Allow notify daily story without add specific skin

### DIFF
--- a/cogs/notify.py
+++ b/cogs/notify.py
@@ -219,7 +219,10 @@ class Notify(commands.Cog):
         db_response = LocalErrorResponse('DATABASE', interaction.locale)
  
         await self.db.is_login(interaction.user.id, db_response) # check if user is logged in
-        self.db.check_notify_list(interaction.user.id) # check total notify list
+
+        if mode == 'Specified Skin': # Check notify list if use mode specified skin
+            self.db.check_notify_list(interaction.user.id) # check total notify list
+
         self.db.change_notify_mode(interaction.user.id, mode) # change notify mode
 
         success = response.get("SUCCESS")

--- a/utils/valorant/db.py
+++ b/utils/valorant/db.py
@@ -77,7 +77,8 @@ class DATABASE:
                 username=player_name,
                 region=region,
                 expiry_token=expiry_token,
-                notify_mode=None
+                notify_mode=None,
+                DM_Message=True
             )
 
             db[str(user_id)] = data


### PR DESCRIPTION
Use `/notify mode mode: All Skin` to get daily store without add specific skin
- Check notify list if mode = Specified Skin only. (All and Off don't use lists)
- Set DM_Message = true by default (if not do this user who never set specific skin can't receive notify because in users.json channel type and DM_Message is empty bot don't know where to send and error lol)